### PR TITLE
Added ability to print non-string items to the terminal

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,6 @@ build
 
 # Codecov
 coverage
+
+# IDE files
+.idea

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v4.1.0
+
+Added ability to print non-string values (objects, functions etc) to the terminal via `Terminal#pushToStdout`
+
 # v4.0.1
 
 Correct eslint-config-standard-react getting installed as a production dependency as opposed to a development one.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-console-emulator",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "A simple terminal emulator component for React.",
   "main": "dist/Terminal.js",
   "files": [

--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -78,7 +78,7 @@ export default class Terminal extends Component {
   }
 
   /**
-   * @param {String} message
+   * @param {Object} message
    * @param {Object} options {
    *  rawInput: Raw input from the terminal (For history),
    *  isEcho: For distinguishing echo messages (Exemption from message styling)
@@ -166,7 +166,10 @@ export default class Terminal extends Component {
           const cmd = this.state.commands[command]
           const res = cmd.fn(...args)
 
-          this.pushToStdout(res)
+          if (typeof res !== 'undefined') {
+            this.pushToStdout(res)
+          }
+
           commandResult.result = res
           if (cmd.explicitExec) cmd.fn(...args)
         }

--- a/src/handlers/parseEOL.js
+++ b/src/handlers/parseEOL.js
@@ -1,5 +1,13 @@
 import innerText from 'react-innertext'
 
+const lineItemToString = (line) => {
+  if (typeof line === 'object') {
+    return JSON.stringify(line)
+  } else {
+    return `${line}`
+  }
+}
+
 export default stdout => {
   const parsedStdout = []
 
@@ -7,11 +15,14 @@ export default stdout => {
     const currentLine = stdout[i]
     const { message, isEcho } = currentLine
 
-    const messageText = innerText(message)
+    if (!isEcho && (typeof message !== 'string')) {
+      parsedStdout.push({ message: lineItemToString(message), isEcho: false })
+      continue
+    }
 
     // Do not parse echoes (Raw inputs)
+    const messageText = innerText(message)
     const parsed = !isEcho && /\\n/g.test(messageText) ? messageText.split(/\\n/g) : [messageText]
-
     for (const line of parsed) {
       parsedStdout.push({ message: line, isEcho: currentLine.isEcho })
     }

--- a/test/Terminal.test.js
+++ b/test/Terminal.test.js
@@ -1,7 +1,7 @@
 /* eslint-disable no-undef, no-unused-vars */
 
 import React from 'react'
-import { shallow, mount, render } from 'enzyme'
+import { shallow, mount } from 'enzyme'
 import skipIf from 'skip-if'
 
 import Terminal from '../src/Terminal'
@@ -62,6 +62,8 @@ const invalidCommands = {
   noFn: {}
 }
 
+const noCommands = {}
+
 beforeAll(async () => {
   await page.goto('http://localhost:8000')
 })
@@ -114,6 +116,45 @@ describe('Terminal welcome messages', () => {
     expect(content.childAt(0).html()).toBe('<div style="line-height: 21px;"><span color="red">test</span></div>')
 
     wrapper.unmount()
+  })
+})
+
+describe('#pushToStdout', () => {
+  let wrapper, instance
+
+  beforeEach(() => {
+    wrapper = mount(<Terminal commands={noCommands}/>)
+    instance = wrapper.instance()
+  })
+
+  afterEach(() => {
+    wrapper.unmount()
+  })
+
+  function expectInputToRender (input, expectedOutput) {
+    instance.pushToStdout(input, {})
+    wrapper.update()
+
+    const content = wrapper.find('[name="react-console-emulator__content"]')
+    expect(content.childAt(0).text()).toBe(expectedOutput)
+  }
+
+  it('Renders a string in the terminal', () => {
+    const input = 'some string value'
+    const expectedOutput = input
+    expectInputToRender(input, expectedOutput)
+  })
+
+  it('Renders an object in the terminal', () => {
+    const input = { a: 123, b: 'xyz' }
+    const expectedOutput = JSON.stringify(input)
+    expectInputToRender(input, expectedOutput)
+  })
+
+  it('Renders a function in the terminal', () => {
+    const input = () => console.log('hi')
+    const expectedOutput = `${input}`
+    expectInputToRender(input, expectedOutput)
   })
 })
 


### PR DESCRIPTION
I'm currently wanting to push not just strings to the terminal, but objects, functions etc to have their string representations rendered. 

This PR accomplishes this, rendering JSON representations of objects, and `toString()` representations for other non-string types. 

I've bumped up the minor version for this PR as well.