### PR TITLE
v5.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,33 @@
+# v5.0.0
+
+This version brings with it some decently sized improvements to react-console-emulator.
+
+### Breaking changes
+
+The recommended method for terminal input text styling has been moved. Terminal input text should now be styled using the `inputTextStyle` and `inputTextClassName` props. **Note:** If using the newly-introduced styling persistence options for command echoes, leaving text styling in `inputStyle` or `inputClassName` may cause unexpected styling bugs.
+
+The `styleEchoBack` prop no longer accepts boolean input. Instead, one should either omit it (For default behaviour) or define one of the string types detailed in the [options](docs/CONFIG.md#options).
+
+### Main changes
+
+Async command executor support is here! You can now use async functions as command handlers and their outputs will function identically to synchronous functions.
+
+Added the ability to hide the prompt area entirely when the terminal is disabled either manually through the `disabled` prop or on process if `disableOnProcess` is enabled ([#639](https://github.com/linuswillner/react-console-emulator/issues/639)).
+
+Added the ability to set the terminal to read-only mode with the `readOnly` prop, which disables input entirely and hides the prompt area ([#639](https://github.com/linuswillner/react-console-emulator/issues/639)).
+
+### Other changes
+
+Fixed a bug where newline parsing did not recognise newline literals properly ([#632](https://github.com/linuswillner/react-console-emulator/issues/632)).
+
+Full run-down of prop changes:
+```diff
++ inputTextStyle
++ inputTextClassName
++ hidePromptWhenDisabled
++ readOnly
+```
+
 # v4.0.1
 
 Correct eslint-config-standard-react getting installed as a production dependency as opposed to a development one.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # v5.0.0
 
-This version brings with it some decently sized improvements to react-console-emulator.
+This version brings with it several new major features to react-console-emulator.
 
 ### Breaking changes
 
@@ -12,13 +12,15 @@ The `styleEchoBack` prop no longer accepts boolean input. Instead, one should ei
 
 Async command executor support is here! You can now use async functions as command handlers and their outputs will function identically to synchronous functions.
 
-Added the ability to hide the prompt area entirely when the terminal is disabled either manually through the `disabled` prop or on process if `disableOnProcess` is enabled ([#639](https://github.com/linuswillner/react-console-emulator/issues/639)).
+Added the ability to hide the prompt area entirely when the terminal is disabled either manually through the `disabled` prop or on process if `disableOnProcess` is enabled. ([#639](https://github.com/linuswillner/react-console-emulator/issues/639))
 
-Added the ability to set the terminal to read-only mode with the `readOnly` prop, which disables input entirely and hides the prompt area ([#639](https://github.com/linuswillner/react-console-emulator/issues/639)).
+Added the ability to set the terminal to read-only mode with the `readOnly` prop, which disables input entirely and hides the prompt area. ([#639](https://github.com/linuswillner/react-console-emulator/issues/639))
+
+Added the ability to lock terminal output to updating the last line only. This could be useful for, among other things, creating progress bars. ([#638](https://github.com/linuswillner/react-console-emulator/issues/638))
 
 ### Other changes
 
-Fixed a bug where newline parsing did not recognise newline literals properly ([#632](https://github.com/linuswillner/react-console-emulator/issues/632)).
+Fixed a bug where newline parsing did not recognise newline literals properly. ([#632](https://github.com/linuswillner/react-console-emulator/issues/632))
 
 Full run-down of prop changes:
 ```diff
@@ -26,6 +28,7 @@ Full run-down of prop changes:
 + inputTextClassName
 + hidePromptWhenDisabled
 + readOnly
++ locked
 ```
 
 # v4.0.1
@@ -46,14 +49,14 @@ Renamed `noAutomaticStdout` prop to `noEchoBack` for added clarity.
 
 ### Main changes
 
-Terminal message styling is here! You can now re-style the messages output by the terminal (Including echoes, optionally with the `styleEchoBack` prop) using the `messageStyle` and `messageClassName` props ([#518](https://github.com/linuswillner/react-console-emulator/issues/518)).
+Terminal message styling is here! You can now re-style the messages output by the terminal (Including echoes, optionally with the `styleEchoBack` prop) using the `messageStyle` and `messageClassName` props. ([#518](https://github.com/linuswillner/react-console-emulator/issues/518))
 
-JSX prompt labels! Prompt labels now support elements instead of just plain old strings ([#210](https://github.com/linuswillner/react-console-emulator/issues/210)).
+JSX prompt labels! Prompt labels now support elements instead of just plain old strings. ([#210](https://github.com/linuswillner/react-console-emulator/issues/210))
 
-Newline parsing is now possible! The terminal can now parse newline characters in terminal messages - anything with a \n character in it will be rendered as a separate line in the response message. This does of course not apply to command back-echoes. This behaviour can also be disabled, if desired, using the `noNewlineParsing` prop ([#519](https://github.com/linuswillner/react-console-emulator/issues/519)).
+Newline parsing is now possible! The terminal can now parse newline characters in terminal messages - anything with a \n character in it will be rendered as a separate line in the response message. This does of course not apply to command back-echoes. This behaviour can also be disabled, if desired, using the `noNewlineParsing` prop. ([#519](https://github.com/linuswillner/react-console-emulator/issues/519))
 
 
-Case-insensitive command matching! You can now supply the `ignoreCommandCase` prop to allow matching commands even when their casing is not correct. Do note that for security reasons, enabling case-insensitive command matching restricts command names to letters, numbers and dashes/underscores ([#415](https://github.com/linuswillner/react-console-emulator/issues/415)).
+Case-insensitive command matching! You can now supply the `ignoreCommandCase` prop to allow matching commands even when their casing is not correct. Do note that for security reasons, enabling case-insensitive command matching restricts command names to letters, numbers and dashes/underscores. ([#415](https://github.com/linuswillner/react-console-emulator/issues/415))
 
 ### Other changes
 
@@ -77,19 +80,19 @@ A full run-down of the prop changes is as follows:
 
 # v3.0.4
 
-Fixed a bug preventing users from selecting text in the terminal output ([#414](https://github.com/linuswillner/react-console-emulator/issues/414)).
+Fixed a bug preventing users from selecting text in the terminal output. ([#414](https://github.com/linuswillner/react-console-emulator/issues/414))
 
 # v3.0.3
 
-Removed redundant `stringify-object` dependency to properly enable command re-validation based on raw objects alone. This was supposed to have been fixed in 3.0.2, but due to a mishap the old validation was left dangling. This has now been fixed ([#411](https://github.com/linuswillner/react-console-emulator/issues/411)).
+Removed redundant `stringify-object` dependency to properly enable command re-validation based on raw objects alone. This was supposed to have been fixed in 3.0.2, but due to a mishap the old validation was left dangling. This has now been fixed. ([#411](https://github.com/linuswillner/react-console-emulator/issues/411))
 
 # v3.0.2
 
-Fixed command re-validation reliability issues relating to source-identical commands ([#35](https://github.com/linuswillner/react-console-emulator/issues/35)).
+Fixed command re-validation reliability issues relating to source-identical commands. ([#35](https://github.com/linuswillner/react-console-emulator/issues/35))
 
 # v3.0.1
 
-Fixed input outline showing on Safari ([#258](https://github.com/linuswillner/react-console-emulator/pull/258)) ([Herve07h22](https://github.com/Herve07h22)).
+Fixed input outline showing on Safari. ([Herve07h22](https://github.com/Herve07h22)) ([#258](https://github.com/linuswillner/react-console-emulator/pull/258)) 
 
 # v3.0.0
 
@@ -149,19 +152,19 @@ Enabled module transpilation to widen the support amongst Node versions for dist
 
 # v1.7.2
 
-Re-added Babel into build flow in a different format to improve compatibility ([#39, comment](https://github.com/linuswillner/react-console-emulator/issues/39#issuecomment-440973765)).
+Re-added Babel into build flow in a different format to improve compatibility. ([#39, comment](https://github.com/linuswillner/react-console-emulator/issues/39#issuecomment-440973765))
 
 # v1.7.1
 
-Removed Babel from the build flow in order to allow the inclusion of the helper files ([#39](https://github.com/linuswillner/react-console-emulator/issues/39)).
+Removed Babel from the build flow in order to allow the inclusion of the helper files. ([#39](https://github.com/linuswillner/react-console-emulator/issues/39))
 
 # v1.7.0
 
 Internal refactoring for better maintainability.
 
-Added default-enabled automatic scrolling to the bottom of the terminal when a command is run ([#36](https://github.com/linuswillner/react-console-emulator/issues/36)).
+Added default-enabled automatic scrolling to the bottom of the terminal when a command is run. ([#36](https://github.com/linuswillner/react-console-emulator/issues/36))
 
-Added command callback support to run a function each time a command is executed ([#36](https://github.com/linuswillner/react-console-emulator/issues/36)).
+Added command callback support to run a function each time a command is executed. ([#36](https://github.com/linuswillner/react-console-emulator/issues/36))
 
 Added `noAutoScroll` and `commandCallback` props.
 

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -103,7 +103,7 @@ export default class App extends Component {
           promptLabelStyle={{ color: '#FFFFFF' }} // Prompt label colour
           inputTextStyle={{ color: 'red' }} // Prompt text colour
           promptLabel={<b>root@React:~$</b>}
-          styleEchoBack='inherit' // Inherit echo styling from prompt
+          styleEchoBack='fullInherit' // Inherit echo styling from prompt
         />
       },
       {

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -189,6 +189,27 @@ export default class App extends Component {
           ]}
           ignoreCommandCase
         />
+      },
+      {
+        title: 'Read-only terminal',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L196-L201',
+        component: <Terminal
+          style={globalStyles}
+          commands={commands}
+          welcomeMessage='This terminal is read-only, and does not take any input.'
+          readOnly
+        />
+      },
+      {
+        title: 'Terminal that disables input on process',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L196-L201',
+        component: <Terminal
+          style={globalStyles}
+          commands={commands}
+          welcomeMessage='This terminal hides the input when the terminal is disabled on command process. Try running the "delay" command and see what happens!'
+          hidePromptWhenDisabled
+          disableOnProcess
+        />
       }
     ]
 

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -101,8 +101,9 @@ export default class App extends Component {
           style={{ backgroundColor: null, background: 'url(\'https://storage.needpix.com/rsynced_images/abstract-wallpaper-1442844111BON.jpg\')' }} // Terminal background
           contentStyle={{ color: '#FF8E00' }} // Text colour
           promptLabelStyle={{ color: '#FFFFFF' }} // Prompt label colour
-          inputStyle={{ color: 'red' }} // Prompt text colour
+          inputTextStyle={{ color: 'red' }} // Prompt text colour
           promptLabel={<b>root@React:~$</b>}
+          styleEchoBack='inherit' // Inherit echo styling from prompt
         />
       },
       {

--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -14,7 +14,14 @@ import Terminal from '../src/Terminal' // In your app, import from 'react-consol
 export default class App extends Component {
   constructor (props) {
     super(props)
+    this.state = {
+      locked: false,
+      increment: 0,
+      isProgressing: false,
+      progress: 0
+    }
     this.terminal = React.createRef()
+    this.progressTerminal = React.createRef()
   }
 
   generateTerminalDemos = (terminals) => {
@@ -50,7 +57,7 @@ export default class App extends Component {
     const terminals = [
       {
         title: 'Default terminal (With autoFocus enabled)',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L55-L57',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L61-L65',
         component: <Terminal
           style={globalStyles}
           commands={commands}
@@ -59,7 +66,7 @@ export default class App extends Component {
       },
       {
         title: 'Default welcome message (With danger mode enabled)',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L64-L67',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L70-L75',
         component: <Terminal
           style={globalStyles}
           commands={commands}
@@ -69,7 +76,7 @@ export default class App extends Component {
       },
       {
         title: 'Custom welcome message as an array, overriding of default commands enabled, custom error message and command callback',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L74-L87',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L80-L95',
         component: <Terminal
           style={globalStyles}
           commands={{
@@ -89,7 +96,7 @@ export default class App extends Component {
       },
       {
         title: 'Custom styles on the terminal elements (Incl. restyling the background) and JSX as prompt label',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L94-L105',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#100-L114',
         component: <Terminal
           commands={commands}
           welcomeMessage={[
@@ -108,7 +115,7 @@ export default class App extends Component {
       },
       {
         title: 'Manual pushing with no echo back (Due to manual pushing) and custom terminal message colours',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L112-L129',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L119-L138',
         component: <Terminal
           style={globalStyles}
           ref={this.terminal}
@@ -132,7 +139,7 @@ export default class App extends Component {
       },
       {
         title: 'History demo',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L136-L138',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L143-L147',
         component: <Terminal
           style={globalStyles}
           commands={commands}
@@ -141,7 +148,7 @@ export default class App extends Component {
       },
       {
         title: 'EOL parsing enabled',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L145-L151',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L152-L160',
         component: <Terminal
           style={globalStyles}
           commands={commands}
@@ -154,7 +161,7 @@ export default class App extends Component {
       },
       {
         title: 'EOL parsing disabled',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L158-L164',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L165-L173',
         component: <Terminal
           style={globalStyles}
           commands={commands}
@@ -167,7 +174,7 @@ export default class App extends Component {
       },
       {
         title: 'Case sensitive command validation',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L171-L176',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L178-L185',
         component: <Terminal
           style={globalStyles}
           commands={casingCommands}
@@ -179,7 +186,7 @@ export default class App extends Component {
       },
       {
         title: 'Case insensitive command validation',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L183-L189',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L190-L198',
         component: <Terminal
           style={globalStyles}
           commands={casingCommands}
@@ -192,7 +199,7 @@ export default class App extends Component {
       },
       {
         title: 'Read-only terminal',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L196-L201',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L203-L208',
         component: <Terminal
           style={globalStyles}
           commands={commands}
@@ -202,13 +209,65 @@ export default class App extends Component {
       },
       {
         title: 'Terminal that disables input on process',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L196-L201',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L213-L219',
         component: <Terminal
           style={globalStyles}
           commands={commands}
           welcomeMessage='This terminal hides the input when the terminal is disabled on command process. Try running the "delay" command and see what happens!'
           hidePromptWhenDisabled
           disableOnProcess
+        />
+      },
+      {
+        title: 'Terminal with conditionally locked output',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L224-L239',
+        component: <Terminal
+          style={globalStyles}
+          commands={{
+            increment: {
+              description: 'Increments a number by one.',
+              fn: () => {
+                this.setState({ locked: true }) // This is just here so the welcome message or anything run before 'increment' doesn't go away
+                const newIncrement = this.state.increment + 1
+                this.setState({ increment: newIncrement })
+                return newIncrement
+              }
+            }
+          }}
+          welcomeMessage='This terminal updates the output of the "increment" command when run multiple times in succession.'
+          locked={this.state.locked}
+        />
+      },
+      {
+        title: 'Progress demo',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L244-L271',
+        component: <Terminal
+          style={globalStyles}
+          ref={this.progressTerminal}
+          commands={{
+            progress: {
+              description: 'Displays a progress counter.',
+              fn: () => {
+                this.setState({ isProgressing: true }, () => {
+                  const terminal = this.progressTerminal.current
+
+                  const interval = setInterval(() => {
+                    if (this.state.progress === 100) { // Stop at 100%
+                      clearInterval(interval)
+                      this.setState({ isProgressing: false, progress: 0 })
+                    } else {
+                      this.setState({ progress: this.state.progress + 1 }, () => terminal.pushToStdout(`Progress: ${this.state.progress}%`))
+                    }
+                  }, 15)
+                })
+
+                return ''
+              }
+            }
+          }}
+          welcomeMessage='This terminal displays a progress counter when you run the "progress" command.'
+          disabled={this.state.isProgressing}
+          locked={this.state.isProgressing}
         />
       }
     ]

--- a/demo/extra/config.js
+++ b/demo/extra/config.js
@@ -13,6 +13,14 @@ export default {
     danger: {
       description: 'This command returns HTML. It will only work with terminals that have dangerous mode.',
       fn: () => 'I can<br/>use HTML in this<br/>and it will be parsed'
+    },
+    async: {
+      description: 'This command runs an asynchronous task',
+      fn: async () => {
+        const asyncTask = async () => 'Hello from a promise!'
+        const result = await asyncTask()
+        return result
+      }
     }
   },
   casingCommands: {

--- a/demo/extra/config.js
+++ b/demo/extra/config.js
@@ -4,22 +4,30 @@ export default {
   },
   commands: {
     echo: {
-      description: 'Echo a passed string.',
+      description: 'Echoes a passed string.',
       usage: 'echo <string>',
       fn: function () {
         return `${Array.from(arguments).join(' ')}`
       }
     },
     danger: {
-      description: 'This command returns HTML. It will only work with terminals that have dangerous mode.',
+      description: 'This command returns HTML. It will only work with terminals that have danger mode enabled.',
       fn: () => 'I can<br/>use HTML in this<br/>and it will be parsed'
     },
     async: {
-      description: 'This command runs an asynchronous task',
+      description: 'This command runs an asynchronous task.',
       fn: async () => {
         const asyncTask = async () => 'Hello from a promise!'
         const result = await asyncTask()
         return result
+      }
+    },
+    delay: {
+      description: 'Delays return of value by 1000 ms.',
+      fn: () => {
+        return new Promise(resolve => {
+          setTimeout(() => resolve('Finished!'), 1000)
+        })
       }
     }
   },

--- a/docs/API.md
+++ b/docs/API.md
@@ -24,13 +24,19 @@ const commands = {
 }
 ```
 
+### Sync vs async command functions
+
+Command functions (The `fn` property) can be sync or async. Asynchronous functions are awaited and their return values are displayed as those of a regular function would.
+
+This is particularly useful if you have to make relatively low-latency operations like network requests and display their outputs. However, if your tasks are predicted 
+
 ### Async output
 
-If you terminal deals with HTTP requests or cross-component functionality, you may need to wait for a result before pushing to the output without relying on the function return time.
+If your terminal commands need to perform tasks with significant delays (Wait for events, etc.) that cause promise resolution times to be prohibitively long, you may need to return a temporary value and then wait for a result before pushing to the output.
 
 **Note:** Doing output this way is a workaround, and ideally your output should be returned by the command function. This method will expose functions to you that you do not normally have access to due to React component encapsulation. Proceed with caution.
 
-To do this, you can use the [React refs API](https://reactjs.org/docs/refs-and-the-dom.html). Below is an example component that uses async pushing.
+To do this, you can use the [React refs API](https://reactjs.org/docs/refs-and-the-dom.html). Below is an example component that uses asynchronous output in this manner.
 
 ```jsx
 import React, { Component } from 'react'

--- a/docs/API.md
+++ b/docs/API.md
@@ -17,6 +17,7 @@ const commands = {
       const lowerCaseArg1 = arg1.toLowerCase()
 
       // What you return in this function will be output to the terminal
+      // If you want to render non-string items, stringify them before outputting them here
       return `test ${lowerCaseArg1}`
     },
     explicitExec: true, // If you need to execute your function again after the output has been emitted, enable
@@ -28,7 +29,7 @@ const commands = {
 
 Command functions (The `fn` property) can be sync or async. Asynchronous functions are awaited and their return values are displayed as those of a regular function would.
 
-This is particularly useful if you have to make relatively low-latency operations like network requests and display their outputs. However, if your tasks are predicted 
+This is particularly useful if you have to make relatively low-latency operations like network requests and display their outputs. However, if your tasks are predicted to take longer than is feasible to wait for with a promise, see the [Async output](#async-output).
 
 ### Async output
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -29,7 +29,11 @@ const commands = {
 
 Command functions (The `fn` property) can be sync or async. Asynchronous functions are awaited and their return values are displayed as those of a regular function would.
 
-This is particularly useful if you have to make relatively low-latency operations like network requests and display their outputs. However, if your tasks are predicted to take longer than is feasible to wait for with a promise, see the [Async output](#async-output).
+This is particularly useful if you have to make relatively low-latency operations like network requests and display their outputs. However, if your tasks are predicted to take longer than is feasible to wait for with a promise, see the [Async output](#async-output) section below.
+
+### Updating terminal output
+
+Akin to native terminals, the terminal output can at will be locked (Using the `locked` prop) to redirect all output to only replace the latest line, as opposed to pushing new lines. This can be utilised along with [Async output](#async-output) to, for example, create a continually incrementing progress bar.
 
 ### Async output
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -35,6 +35,8 @@ This is particularly useful if you have to make relatively low-latency operation
 
 Akin to native terminals, the terminal output can at will be locked (Using the `locked` prop) to redirect all output to only replace the latest line, as opposed to pushing new lines. This can be utilised along with [Async output](#async-output) to, for example, create a continually incrementing progress bar.
 
+**Note:** It might be worth setting the `locked` prop conditionally only when a command is run, if you do not want your welcome message to disappear, or get stripped down to only the last one if you're using a multi-message welcome, considering welcome messages behave exactly like ordinary user-triggered outputs.
+
 ### Async output
 
 If your terminal commands need to perform tasks with significant delays (Wait for events, etc.) that cause promise resolution times to be prohibitively long, you may need to return a temporary value and then wait for a result before pushing to the output.

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -40,6 +40,7 @@ The terminal has several options you can use to change the behaviour of it. All 
 | errorText | The text to display when a command does not exist. Use the `[command]` placeholder for input substitution. | String | `'Command \'[command]\' not found!'` |
 | hidePromptWhenDisabled | Hide entire prompt when input is manually disabled (Via the `disabled` prop) or when `disableOnProcess` is enabled and the terminal is processing. | Boolean | `false` |
 | ignoreCommandCase | Disable case-sensitive matching of command inputs. **Note:** Enabling this feature results in a restriction of command names to alphanumeric characters, dashes and underscores, for security reasons. | Boolean | `false` |
+| locked | Lock output to the current line. When this prop is set to `true`, all output to the terminal will only replace the latest line. This could be useful if you want to make something akin to a progress bar and update the latest line. | Boolean | `false` |
 | noAutoScroll | Disable automatic scrolling to the bottom of the terminal when a command is executed (*nix-like). | Boolean | `false` |
 | noDefaults | Do not register the default commands (`help` and `clear`). Useful if you want to override the functionality of either. | Boolean | `false` |
 | noEchoBack | Disable command echoes (Terminal outputs of any commands entered). | Boolean | `false` |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -27,20 +27,9 @@ commandCallback={result => console.log(result)}
 */
 ```
 
-
-### Changing labels
-
-The different labels used by the terminal can be easily changed via the following props.
-
-| Prop | Description | Type | Default |
-| ---- | ----------- | ---- | ------- |
-| welcomeMessage | The terminal welcome message. Set to `false` to disable, `true` to show the default, or supply a string (Or an array of them) to set a custom one. | Boolean/String/Array<String\> | `false` |
-| promptLabel | The prefix to use for the input field. Can be either string or element. | Node | `$` |
-| errorText | The text to display when a command does not exist. Use the `[command]` placeholder for input substitution. | String | `Command '[command]' not found!` |
-
 ### Options
 
-The terminal has several options you can use to change the behaviour of it.
+The terminal has several options you can use to change the behaviour of it. All props in this section are optional.
 
 | Prop | Description | Type | Default |
 | ---- | ----------- | ---- | ------- |
@@ -48,13 +37,16 @@ The terminal has several options you can use to change the behaviour of it.
 | dangerMode | Enable parsing of HTML in terminal messages. | Boolean | `false` |
 | disabled | Whether to enable terminal input or not. | Boolean | `false` |
 | disableOnProcess | Disable input to the terminal during command execution. | Boolean | `false` |
-| styleEchoBack | Style command echoes (Terminal outputs of any commands entered) as regular terminal messages. | Boolean | `false` |
+| errorText | The text to display when a command does not exist. Use the `[command]` placeholder for input substitution. | String | `'Command \'[command]\' not found!'` |
+| ignoreCommandCase | Disable case-sensitive matching of command inputs. **Note:** Enabling this feature results in a restriction of command names to alphanumeric characters, dashes and underscores, for security reasons. | Boolean | `false` |
+| noAutoScroll | Disable automatic scrolling to the bottom of the terminal when a command is executed (*nix-like). | Boolean | `false` |
 | noDefaults | Do not register the default commands (`help` and `clear`). Useful if you want to override the functionality of either. | Boolean | `false` |
 | noEchoBack | Disable command echoes (Terminal outputs of any commands entered). | Boolean | `false` |
 | noHistory | Disable the storing and scrolling of history of the commands entered in the terminal. | Boolean | `false` |
-| noAutoScroll | Disable automatic scrolling to the bottom of the terminal when a command is executed (*nix-like). | Boolean | `false` |
 | noNewlineParsing | Disable the parsing line breaks (\n) in command outputs as separate message, leave them unchanged. | Boolean | `false` |
-| ignoreCommandCase | Disable case-sensitive matching of command inputs. **Note:** Enabling this feature results in a restriction of command names to alphanumeric characters, dashes and underscores, for security reasons. | Boolean | `false` |
+| promptLabel | The prefix to use for the input field. Can be either string or element. | Node | `$` |
+| styleEchoBack | Inherit style for command echoes (Terminal outputs of any commands entered) from prompt (Fully or partially), or style them as regular messages. Omitting this prop enables default behaviour. | String | `false` |
+| welcomeMessage | The terminal welcome message. Set to `false` to disable, `true` to show the default, or supply a string (Or an array of them) to set a custom one. | Boolean/String/Array<String\> | `false` |
 
 ### Re-styling
 
@@ -62,13 +54,20 @@ To re-style the terminal, you have two options: [Inline styles](https://reactjs.
 
 The default styles for the terminal can be found in [src/defs/styles/Terminal.js](../src/defs/styles/Terminal.js). The definitions contained within can be adjusted by submitting style overrides or class names to the following props.
 
+All props in this section are optional.
+
 | Prop | Target |
 | ---- | ------ |
 | style / className | Terminal root container. |
 | contentStyle / contentClassName | Terminal content container. |
 | inputAreaStyle / inputAreaClassName | Input area element (Container for prompt label and input field). |
 | promptLabelStyle / promptLabelClassName | Prompt label (The prefix for the input). |
-| inputStyle / inputClassName | Text input field. |
+| inputStyle / inputClassName | Input field. **Note:** Applying styles for the text here may cause unexpected results, see below. |
+| inputTextStyle / inputTextClassName | Input field text. |
 | messageStyle / messageClassName | Terminal messages (Incl. command echoes if enabled via the `styleEchoBack` prop). |
+
+**Note about input text styling:**
+
+As of v5.0.0, input text styling has been moved to `inputTextStyle` and `inputTextClassName`. The reason for this is the introduction of prompt styling persistence for echoes in the same version. Despite the input text being part of the input element strictly speaking, **do not apply text styles in `inputStyle` or `inputClassName`, or you may see unexpected styling errors.**
 
 Examples on how to override the terminal styles can be found in [src/App.jsx](../src/App.jsx).

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -38,6 +38,7 @@ The terminal has several options you can use to change the behaviour of it. All 
 | disabled | Whether to enable terminal input or not. | Boolean | `false` |
 | disableOnProcess | Disable input to the terminal during command execution. | Boolean | `false` |
 | errorText | The text to display when a command does not exist. Use the `[command]` placeholder for input substitution. | String | `'Command \'[command]\' not found!'` |
+| hidePromptWhenDisabled | Hide entire prompt when input is manually disabled (Via the `disabled` prop) or when `disableOnProcess` is enabled and the terminal is processing. | Boolean | `false` |
 | ignoreCommandCase | Disable case-sensitive matching of command inputs. **Note:** Enabling this feature results in a restriction of command names to alphanumeric characters, dashes and underscores, for security reasons. | Boolean | `false` |
 | noAutoScroll | Disable automatic scrolling to the bottom of the terminal when a command is executed (*nix-like). | Boolean | `false` |
 | noDefaults | Do not register the default commands (`help` and `clear`). Useful if you want to override the functionality of either. | Boolean | `false` |

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -45,7 +45,8 @@ The terminal has several options you can use to change the behaviour of it. All 
 | noHistory | Disable the storing and scrolling of history of the commands entered in the terminal. | Boolean | `false` |
 | noNewlineParsing | Disable the parsing line breaks (\n) in command outputs as separate message, leave them unchanged. | Boolean | `false` |
 | promptLabel | The prefix to use for the input field. Can be either string or element. | Node | `$` |
-| styleEchoBack | Inherit style for command echoes (Terminal outputs of any commands entered) from prompt (Fully or partially), or style them as regular messages. Omitting this prop enables default behaviour. | String | `false` |
+| readOnly | Hides the entire prompt, thus setting the terminal to read-only mode. | Boolean | `false` |
+| styleEchoBack | Inherit style for command echoes (Terminal outputs of any commands entered) from prompt (Fully or partially, i.e. label or text only), or style them as regular messages. Omitting this prop enables default behaviour. | String<'labelOnly'/'textOnly'/'fullInherit'/'messageInherit'\> | `undefined` |
 | welcomeMessage | The terminal welcome message. Set to `false` to disable, `true` to show the default, or supply a string (Or an array of them) to set a custom one. | Boolean/String/Array<String\> | `false` |
 
 ### Re-styling

--- a/jest.coverage.js
+++ b/jest.coverage.js
@@ -10,7 +10,8 @@ module.exports = {
     // These are covered by interactivity tests or other tests
     'cleanArray.js',
     'scrollHistory.js',
-    'sendCursorToEnd.js'
+    'sendCursorToEnd.js',
+    'constructEcho.js'
   ],
   coverageDirectory: './coverage/'
 }

--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -26,7 +26,6 @@ export default class Terminal extends Component {
       history: [],
       historyPosition: null,
       previousHistoryPosition: null,
-      // TODO: Add prop-controlled enable/disable on the input
       processing: false
     }
 

--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -17,6 +17,7 @@ import types from './defs/types/Terminal'
 // Utils
 import commandExists from './utils/commandExists'
 import constructEcho from './utils/constructEcho'
+import shouldPromptBeVisible from './utils/shouldPromptBeVisible'
 
 export default class Terminal extends Component {
   constructor (props) {
@@ -40,7 +41,8 @@ export default class Terminal extends Component {
   focusTerminal = () => {
     // Only focus the terminal if text isn't being copied
     const isTextSelected = window.getSelection().type === 'Range'
-    if (!isTextSelected) this.terminalInput.current.focus()
+    // Only focus if input is there (Goes away for read-only terminals)
+    if (!isTextSelected) this.terminalInput.current.focus() // eslint-disable-line no-unused-expressions
   }
 
   /* istanbul ignore next: Covered by interactivity tests */
@@ -242,7 +244,7 @@ export default class Terminal extends Component {
           <div
             name='react-console-emulator__inputArea'
             className={this.props.inputAreaClassName}
-            style={styles.inputArea}
+            style={shouldPromptBeVisible(this.state, this.props) ? styles.inputArea : { display: 'none' }}
           >
             {/* Prompt label */}
             <span
@@ -261,10 +263,7 @@ export default class Terminal extends Component {
               onKeyDown={this.handleInput}
               type='text'
               autoComplete='off'
-              disabled={
-                this.props.disabled ||
-                (this.props.disableOnProcess && /* istanbul ignore next: Covered by interactivity tests */ this.state.processing)
-              }
+              disabled={this.props.disabled || (this.props.disableOnProcess && /* istanbul ignore next: Covered by interactivity tests */ this.state.processing)}
             />
           </div>
         </div>

--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -16,6 +16,7 @@ import types from './defs/types/Terminal'
 
 // Utils
 import commandExists from './utils/commandExists'
+import constructEcho from './utils/constructEcho'
 
 export default class Terminal extends Component {
   constructor (props) {
@@ -139,10 +140,7 @@ export default class Terminal extends Component {
 
       if (!this.props.noEchoBack) {
         // Mimic native terminal by echoing command back
-        // Also exempt it from message since it should not really be a message despite behaving like one
-        // Containing it in a span to allow JSX values in the prompt label
-        const echo = <span>{this.props.promptLabel || '$'} {rawInput}</span>
-        this.pushToStdout(echo, { isEcho: true })
+        this.pushToStdout(constructEcho(this.props.promptLabel || '$', rawInput, this.props), { isEcho: true })
       }
 
       if (rawInput) {
@@ -221,7 +219,7 @@ export default class Terminal extends Component {
       content: defaults(this.props.contentStyle, sourceStyles.content),
       inputArea: defaults(this.props.inputAreaStyle, sourceStyles.inputArea),
       promptLabel: defaults(this.props.promptLabelStyle, sourceStyles.promptLabel),
-      input: defaults(this.props.inputStyle, sourceStyles.input)
+      input: defaults({ ...this.props.inputStyle, ...this.props.inputTextStyle }, { ...sourceStyles.input, ...sourceStyles.inputText })
     }
 
     return (

--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -88,6 +88,9 @@ export default class Terminal extends Component {
    */
   pushToStdout = (message, options) => {
     const { stdout } = this.state
+
+    if (this.props.locked) stdout.pop()
+
     stdout.push({ message, isEcho: options?.isEcho || false })
 
     /* istanbul ignore next: Covered by interactivity tests */

--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -131,7 +131,7 @@ export default class Terminal extends Component {
 
   /* istanbul ignore next: Covered by interactivity tests */
   processCommand = () => {
-    this.setState({ processing: true }, () => {
+    this.setState({ processing: true }, async () => {
       // Initialise command result object
       const commandResult = { command: null, args: [], rawInput: null, result: null }
       const rawInput = this.terminalInput.current.value
@@ -164,11 +164,11 @@ export default class Terminal extends Component {
           )
         } else {
           const cmd = this.state.commands[command]
-          const res = cmd.fn(...args)
+          const res = await cmd.fn(...args)
 
           this.pushToStdout(res)
           commandResult.result = res
-          if (cmd.explicitExec) cmd.fn(...args)
+          if (cmd.explicitExec) await cmd.fn(...args)
         }
       }
 

--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -42,7 +42,7 @@ export default class Terminal extends Component {
     // Only focus the terminal if text isn't being copied
     const isTextSelected = window.getSelection().type === 'Range'
     // Only focus if input is there (Goes away for read-only terminals)
-    if (!isTextSelected) this.terminalInput.current.focus() // eslint-disable-line no-unused-expressions
+    if (!isTextSelected) this.terminalInput.current.focus()
   }
 
   /* istanbul ignore next: Covered by interactivity tests */

--- a/src/defs/styles/Terminal.js
+++ b/src/defs/styles/Terminal.js
@@ -25,6 +25,11 @@ export default {
     paddingTop: '3px',
     color: '#EE9C34'
   },
+  inputText: {
+    fontSize: '15px',
+    color: '#F0BF81',
+    fontFamily: 'monospace'
+  },
   input: {
     border: '0',
     padding: '0 0 0 7px',
@@ -33,9 +38,6 @@ export default {
     width: '100%',
     height: '22px',
     background: 'transparent',
-    fontSize: '15px',
-    color: '#F0BF81',
-    fontFamily: 'monospace',
     outline: 'none' // Fix for outline showing up on some browsers
   }
 }

--- a/src/defs/types/Terminal.js
+++ b/src/defs/types/Terminal.js
@@ -5,7 +5,8 @@ const styleTypes = {
   contentStyle: PropTypes.object,
   inputAreaStyle: PropTypes.object,
   promptLabelStyle: PropTypes.object,
-  inputStyle: PropTypes.object
+  inputStyle: PropTypes.object,
+  inputTextStyle: PropTypes.object
 }
 
 const classNameTypes = {
@@ -19,6 +20,7 @@ const classNameTypes = {
 const optionTypes = {
   autoFocus: PropTypes.bool,
   dangerMode: PropTypes.bool,
+  styleEchoBack: PropTypes.bool,
   disabled: PropTypes.bool,
   disableOnProcess: PropTypes.bool,
   ignoreCommandCase: PropTypes.bool,

--- a/src/defs/types/Terminal.js
+++ b/src/defs/types/Terminal.js
@@ -14,13 +14,21 @@ const classNameTypes = {
   contentClassName: PropTypes.string,
   inputAreaClassName: PropTypes.string,
   promptLabelClassName: PropTypes.string,
-  inputClassName: PropTypes.string
+  inputClassName: PropTypes.string,
+  inputTextClassName: PropTypes.string
 }
 
 const optionTypes = {
   autoFocus: PropTypes.bool,
   dangerMode: PropTypes.bool,
-  styleEchoBack: PropTypes.bool,
+  styleEchoBack: PropTypes.oneOf([
+    'labelOnly', // Only persist label style
+    'textOnly', // Only persist text style
+    'inherit', // Persist entire prompt style
+    'message' // Inherit message style
+    // (undefined signifies default behaviour)
+    // Not offering individual options for message styling as messages only have one uniform style for the entire element per the spec
+  ]),
   disabled: PropTypes.bool,
   disableOnProcess: PropTypes.bool,
   ignoreCommandCase: PropTypes.bool,

--- a/src/defs/types/Terminal.js
+++ b/src/defs/types/Terminal.js
@@ -24,8 +24,8 @@ const optionTypes = {
   styleEchoBack: PropTypes.oneOf([
     'labelOnly', // Only persist label style
     'textOnly', // Only persist text style
-    'inherit', // Persist entire prompt style
-    'message' // Inherit message style
+    'fullInherit', // Inherit entire prompt style
+    'messageInherit' // Inherit message style
     // (undefined signifies default behaviour)
     // Not offering individual options for message styling as messages only have one uniform style for the entire element per the spec
   ]),

--- a/src/defs/types/Terminal.js
+++ b/src/defs/types/Terminal.js
@@ -29,6 +29,7 @@ const optionTypes = {
     // (undefined signifies default behaviour)
     // Not offering individual options for message styling as messages only have one uniform style for the entire element per the spec
   ]),
+  locked: PropTypes.bool,
   readOnly: PropTypes.bool,
   disabled: PropTypes.bool,
   disableOnProcess: PropTypes.bool,

--- a/src/defs/types/Terminal.js
+++ b/src/defs/types/Terminal.js
@@ -29,8 +29,10 @@ const optionTypes = {
     // (undefined signifies default behaviour)
     // Not offering individual options for message styling as messages only have one uniform style for the entire element per the spec
   ]),
+  readOnly: PropTypes.bool,
   disabled: PropTypes.bool,
   disableOnProcess: PropTypes.bool,
+  hidePromptWhenDisabled: PropTypes.bool,
   ignoreCommandCase: PropTypes.bool,
   noDefaults: PropTypes.bool,
   noEchoBack: PropTypes.bool,

--- a/src/handlers/parseEOL.js
+++ b/src/handlers/parseEOL.js
@@ -10,7 +10,7 @@ export default stdout => {
     const messageText = innerText(message)
 
     // Do not parse echoes (Raw inputs)
-    const parsed = !isEcho && /\n|\\n/g.test(messageText) ? messageText.split(/\n|\\n/g) : [messageText]
+    const parsed = !isEcho && /\n|\\n/g.test(messageText) ? messageText.split(/\n|\\n/g) : [message]
 
     for (const line of parsed) {
       parsedStdout.push({ message: line, isEcho: currentLine.isEcho })

--- a/src/handlers/parseEOL.js
+++ b/src/handlers/parseEOL.js
@@ -10,7 +10,7 @@ export default stdout => {
     const messageText = innerText(message)
 
     // Do not parse echoes (Raw inputs)
-    const parsed = !isEcho && /\\n/g.test(messageText) ? messageText.split(/\\n/g) : [messageText]
+    const parsed = !isEcho && /\n|\\n/g.test(messageText) ? messageText.split(/\n|\\n/g) : [messageText]
 
     for (const line of parsed) {
       parsedStdout.push({ message: line, isEcho: currentLine.isEcho })

--- a/src/utils/constructEcho.js
+++ b/src/utils/constructEcho.js
@@ -44,8 +44,8 @@ export default (promptLabel, rawInput, stylingProps) => {
   // This is because variable reassignment in switch statements gets really hairy really quick
   const styles = (() => {
     switch (stylingProps.styleEchoBack) {
-      case 'inherit': return sources.echo
-      case 'message': return sources.message
+      case 'fullInherit': return sources.echo
+      case 'messageInherit': return sources.message
       case 'labelOnly': return {
         label: sources.echo.label,
         text: {}

--- a/src/utils/constructEcho.js
+++ b/src/utils/constructEcho.js
@@ -1,0 +1,70 @@
+import React from 'react'
+import defaults from 'defaults'
+import terminalSourceStyles from '../defs/styles/Terminal'
+import messageSourceStyles from '../defs/styles/TerminalMessage'
+
+/**
+ * Constructs command echo based on user's styling options
+ * @param promptLabel - Prompt label element
+ * @param rawInput - Raw command input
+ * @param stylingProps - {
+ *  styleEchoBack: string
+ *  promptLabelClassName: string,
+ *  promptLabelStyle: object,
+ *  inputTextClassName: string,
+ *  inputTextStyle: object
+ * }
+ */
+export default (promptLabel, rawInput, stylingProps) => {
+  const sources = {
+    echo: {
+      label: {
+        className: stylingProps.promptLabelClassName,
+        style: defaults(stylingProps.promptLabelStyle, terminalSourceStyles.promptLabel)
+      },
+      text: {
+        className: stylingProps.inputTextClassName,
+        style: defaults(stylingProps.inputTextStyle, terminalSourceStyles.inputText)
+      }
+    },
+    // Note: Not offering individual options for message styling as messages only have one uniform style for the entire element per the spec
+    message: {
+      label: {
+        className: stylingProps.messageClassName,
+        style: defaults(stylingProps.messageStyle, messageSourceStyles)
+      },
+      text: {
+        className: stylingProps.messageClassName,
+        style: defaults(stylingProps.messageStyle, messageSourceStyles)
+      }
+    }
+  }
+
+  // Getting these via an IIFE so I can use returns
+  // This is because variable reassignment in switch statements gets really hairy really quick
+  const styles = (() => {
+    switch (stylingProps.styleEchoBack) {
+      case 'inherit': return sources.echo
+      case 'message': return sources.message
+      case 'labelOnly': return {
+        label: sources.echo.label,
+        text: {}
+      }
+      case 'textOnly': return {
+        label: {},
+        text: sources.echo.text
+      }
+      default: return {
+        label: {},
+        text: {}
+      }
+    }
+  })()
+
+  return (
+    <div>
+      <span {...styles.label}>{promptLabel} </span>
+      <span {...styles.text}>{rawInput}</span>
+    </div>
+  )
+}

--- a/src/utils/shouldPromptBeVisible.js
+++ b/src/utils/shouldPromptBeVisible.js
@@ -1,0 +1,17 @@
+export default (state, props) => {
+  const isNotReadOnly = !props.readOnly
+
+  const shouldHideWhenDisabled = props.hidePromptWhenDisabled
+  const shouldDisableOnProcess = props.disableOnProcess
+  const isDisabled = props.disabled
+  const isProcessing = state.processing
+
+  // If prompt should be hidden when disabled...
+  if (shouldHideWhenDisabled) {
+    if (isDisabled) return false // ...hide on explicit prop-controlled disable...
+    else if (shouldDisableOnProcess && isProcessing) return false // ...or when disabling on process is enabled and terminal is processing.
+  }
+
+  // If no above conditions were met, the read-only state controls whether the prompt should be visible or not
+  return isNotReadOnly
+}

--- a/src/utils/shouldPromptBeVisible.js
+++ b/src/utils/shouldPromptBeVisible.js
@@ -7,6 +7,7 @@ export default (state, props) => {
   const isProcessing = state.processing
 
   // If prompt should be hidden when disabled...
+  /* istanbul ignore if: Covered by interactivity tests */
   if (shouldHideWhenDisabled) {
     if (isDisabled) return false // ...hide on explicit prop-controlled disable...
     else if (shouldDisableOnProcess && isProcessing) return false // ...or when disabling on process is enabled and terminal is processing.

--- a/test/Terminal.test.js
+++ b/test/Terminal.test.js
@@ -139,8 +139,8 @@ describe('Terminal functionality', () => {
   })
 
   it('Parses newlines (But not when disabled)', () => {
-    const wrapperEnabled = mount(<Terminal commands={commands} welcomeMessage={'split1\\nsplit2'}/>)
-    const wrapperDisabled = mount(<Terminal commands={commands} welcomeMessage={'split1\\nsplit2'} noNewlineParsing/>)
+    const wrapperEnabled = mount(<Terminal commands={commands} welcomeMessage={'split1\nsplit2'}/>)
+    const wrapperDisabled = mount(<Terminal commands={commands} welcomeMessage={'split1\nsplit2'} noNewlineParsing/>)
 
     const enabledContent = wrapperEnabled.find('[name="react-console-emulator__content"]')
     const disabledContent = wrapperDisabled.find('[name="react-console-emulator__content"]')
@@ -150,7 +150,7 @@ describe('Terminal functionality', () => {
     expect(enabledContent.childAt(1).text()).toBe('split2')
 
     // ...and doesn't with parsing disabled
-    expect(disabledContent.childAt(0).text()).toBe('split1\\nsplit2')
+    expect(disabledContent.childAt(0).text()).toBe('split1\nsplit2')
 
     wrapperEnabled.unmount()
     wrapperDisabled.unmount()

--- a/test/Terminal.test.js
+++ b/test/Terminal.test.js
@@ -76,6 +76,11 @@ describe('Terminal HTML structure', () => {
     expect(wrapper.find('[name="react-console-emulator__promptLabel"]')).toHaveLength(1)
     expect(wrapper.find('[name="react-console-emulator__input"]')).toHaveLength(1)
   })
+
+  it('Hides the prompt in read-only mode', () => {
+    const wrapper = shallow(<Terminal commands={commands} readOnly/>)
+    expect(wrapper.find('[name="react-console-emulator__inputArea"]').prop('style')).toEqual({ display: 'none' })
+  })
 })
 
 describe('Terminal welcome messages', () => {

--- a/test/Terminal.test.js
+++ b/test/Terminal.test.js
@@ -160,6 +160,15 @@ describe('Terminal functionality', () => {
     wrapperEnabled.unmount()
     wrapperDisabled.unmount()
   })
+
+  it('Only updates the last line when locked', () => {
+    const wrapper = mount(<Terminal commands={commands} welcomeMessage={['this is the first message', 'this is the second message']} locked/>)
+    const content = wrapper.find('[name="react-console-emulator__content"]')
+
+    expect(content.childAt(0).text()).toBe('this is the second message')
+
+    wrapper.unmount()
+  })
 })
 
 describe('Terminal command validator', () => {


### PR DESCRIPTION
This version brings with it several new major features to react-console-emulator.

### Breaking changes

The recommended method for terminal input text styling has been moved. Terminal input text should now be styled using the `inputTextStyle` and `inputTextClassName` props. **Note:** If using the newly-introduced styling persistence options for command echoes, leaving text styling in `inputStyle` or `inputClassName` may cause unexpected styling bugs.

The `styleEchoBack` prop no longer accepts boolean input. Instead, one should either omit it (For default behaviour) or define one of the string types detailed in the [options](docs/CONFIG.md#options).

### Main changes

Async command executor support is here! You can now use async functions as command handlers and their outputs will function identically to synchronous functions.

Added the ability to hide the prompt area entirely when the terminal is disabled either manually through the `disabled` prop or on process if `disableOnProcess` is enabled ([#639](https://github.com/linuswillner/react-console-emulator/issues/639)).

Added the ability to set the terminal to read-only mode with the `readOnly` prop, which disables input entirely and hides the prompt area ([#639](https://github.com/linuswillner/react-console-emulator/issues/639)).

### Other changes

Fixed a bug where newline parsing did not recognise newline literals properly ([#632](https://github.com/linuswillner/react-console-emulator/issues/632)).

Full run-down of prop changes:
```diff
+ inputTextStyle
+ inputTextClassName
+ hidePromptWhenDisabled
+ readOnly
```

Closes #632 
Closes #638 
Closes #639 
Closes #640 