### PR TITLE
fix(dangerMode): dont convert objects to HTML

### DIFF
--- a/demo/App.jsx
+++ b/demo/App.jsx
@@ -239,8 +239,18 @@ export default class App extends Component {
         />
       },
       {
+        title: 'Raw HTML output',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L244-L249',
+        component: <Terminal
+          style={globalStyles}
+          commands={commands}
+          welcomeMessage='This terminal should render raw HTML to stdout. Try running the `html` command to see what happens!'
+          dangerMode
+        />
+      },
+      {
         title: 'Progress demo',
-        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L244-L271',
+        link: 'https://github.com/linuswillner/react-console-emulator/blob/master/demo/App.jsx#L254-L281',
         component: <Terminal
           style={globalStyles}
           ref={this.progressTerminal}

--- a/demo/extra/config.js
+++ b/demo/extra/config.js
@@ -29,6 +29,10 @@ export default {
           setTimeout(() => resolve('Finished!'), 1000)
         })
       }
+    },
+    html: {
+      description: 'Returns a raw HTML string.',
+      fn: async () => '<span style="color:#c386ff">Hello</span> <span style="color:#fa8072">World</span>'
     }
   },
   casingCommands: {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
     "codecov": "codecov --disable=gcov",
     "test": "npm run lint && npm run test-coverage && npm run codecov",
     "test-local": "npm run lint && npm run test-coverage",
+    "test-watch": "npm run test-local -- -- --watch",
     "test-coverage": "cross-env TEST=true jest --config jest.coverage.js",
     "test-nocoverage": "cross-env TEST=true jest --config jest.default.js",
     "prepublishOnly": "npm run compile"

--- a/src/TerminalMessage.jsx
+++ b/src/TerminalMessage.jsx
@@ -15,7 +15,7 @@ export default class TerminalMessage extends Component {
       message: defaults(style, sourceStyles)
     }
 
-    return this.props.dangerMode
+    return this.props.dangerMode && typeof content === 'string'
       ? <div className={className} style={styles.message} {...html(content)}/>
       : <div className={className} style={styles.message}>{content}</div>
   }


### PR DESCRIPTION
### Changes
- [x] **Fix  linuswillner/react-console-emulator#860**
  
  [Don't run the `html()` conversion method on non-string inputs][fix] when the terminal is in `[dangerMode]`. (I tried to add a test for this as well, but I wasn't actually able to reproduce the problem in the Jest env… 😬)

  https://github.com/linuswillner/react-console-emulator/blob/1d1fabbd21f48a446204f9f22c68685152e32bd5/src/TerminalMessage.jsx#L18-L19

- [x] **Add a new `test-watch` NPM script**.
  Not really relevant to the changes herein, but it *is* convenient!

### Testing
Check out [this forked branch][branch] locally and `start` the demo. Scroll down to the new "Raw HTML Output" demo and try running the `html` command. If you see colorful output and you *don't* see the `[object Object]` error, this worked!

[fix]: https://github.com/linuswillner/react-console-emulator/pull/964/files#diff-a1bc48229c5612724da421aefff8ef8803becd182cd4001d51cf780666f8268bR18 "truly a one-liner fix!"
[branch]: https://github.com/rafegoldberg/react-console-emulator/tree/fix/dangerMode/dont-parse-objects-as-html