### PR TITLE
Made maxOutput Prop

### DIFF
--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -50,6 +50,7 @@ The terminal has several options you can use to change the behaviour of it. All 
 | readOnly | Hides the entire prompt, thus setting the terminal to read-only mode. | Boolean | `false` |
 | styleEchoBack | Inherit style for command echoes (Terminal outputs of any commands entered) from prompt (Fully or partially, i.e. label or text only), or style them as regular messages. Omitting this prop enables default behaviour. | String<'labelOnly'/'textOnly'/'fullInherit'/'messageInherit'\> | `undefined` |
 | welcomeMessage | The terminal welcome message. Set to `false` to disable, `true` to show the default, or supply a string (Or an array of them) to set a custom one. | Boolean/String/Array<String\> | `false` |
+| maxOutput | The maximum amount of output lines in the terminal. Set to integer to cap output lines at that amount, set to false for there to be no cap. | Boolean/Number | `false` |
 
 ### Re-styling
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -50,7 +50,7 @@ The terminal has several options you can use to change the behaviour of it. All 
 | readOnly | Hides the entire prompt, thus setting the terminal to read-only mode. | Boolean | `false` |
 | styleEchoBack | Inherit style for command echoes (Terminal outputs of any commands entered) from prompt (Fully or partially, i.e. label or text only), or style them as regular messages. Omitting this prop enables default behaviour. | String<'labelOnly'/'textOnly'/'fullInherit'/'messageInherit'\> | `undefined` |
 | welcomeMessage | The terminal welcome message. Set to `false` to disable, `true` to show the default, or supply a string (Or an array of them) to set a custom one. | Boolean/String/Array<String\> | `false` |
-| maxOutput | The maximum amount of output lines in the terminal. Set to integer to cap output lines at that amount, set to false for there to be no cap. | Boolean/Number | `false` |
+| maxOutput | The maximum amount of output lines in the terminal. Set to integer to cap output lines at that amount, set to 0 for there to be no cap. | Number | `0` |
 
 ### Re-styling
 

--- a/docs/CONFIG.md
+++ b/docs/CONFIG.md
@@ -50,7 +50,7 @@ The terminal has several options you can use to change the behaviour of it. All 
 | readOnly | Hides the entire prompt, thus setting the terminal to read-only mode. | Boolean | `false` |
 | styleEchoBack | Inherit style for command echoes (Terminal outputs of any commands entered) from prompt (Fully or partially, i.e. label or text only), or style them as regular messages. Omitting this prop enables default behaviour. | String<'labelOnly'/'textOnly'/'fullInherit'/'messageInherit'\> | `undefined` |
 | welcomeMessage | The terminal welcome message. Set to `false` to disable, `true` to show the default, or supply a string (Or an array of them) to set a custom one. | Boolean/String/Array<String\> | `false` |
-| maxOutput | The maximum amount of output lines in the terminal. Set to integer to cap output lines at that amount, set to 0 for there to be no cap. | Number | `0` |
+| maxOutput | The maximum amount of output lines in the terminal. Set to integer to cap output lines at that amount, set to 0 for there to be no cap. Omitting this prop enables default behaviour. | Number | `0` |
 
 ### Re-styling
 

--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -90,7 +90,8 @@ export default class Terminal extends Component {
     const { stdout } = this.state
 
     if (this.props.locked) stdout.pop()
-
+    if (stdout.length > this.props.maxOutput && typeof this.props.maxOutput === "number") stdout.shift()
+    
     stdout.push({ message, isEcho: options?.isEcho || false })
 
     /* istanbul ignore next: Covered by interactivity tests */

--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -90,7 +90,7 @@ export default class Terminal extends Component {
     const { stdout } = this.state
 
     if (this.props.locked) stdout.pop()
-    if (stdout.length >= this.props.maxOutput && this.props.maxOutput > 0) stdout.shift()
+    if (this.props.maxOutput && stdout.length >= this.props.maxOutput) stdout.shift()
     
     stdout.push({ message, isEcho: options?.isEcho || false })
 

--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -90,7 +90,7 @@ export default class Terminal extends Component {
     const { stdout } = this.state
 
     if (this.props.locked) stdout.pop()
-    if (stdout.length + 1 > this.props.maxOutput && this.props.maxOutput > 0) stdout.shift()
+    if (stdout.length >= this.props.maxOutput && this.props.maxOutput > 0) stdout.shift()
     
     stdout.push({ message, isEcho: options?.isEcho || false })
 

--- a/src/Terminal.jsx
+++ b/src/Terminal.jsx
@@ -90,7 +90,7 @@ export default class Terminal extends Component {
     const { stdout } = this.state
 
     if (this.props.locked) stdout.pop()
-    if (stdout.length > this.props.maxOutput && typeof this.props.maxOutput === "number") stdout.shift()
+    if (stdout.length + 1 > this.props.maxOutput && this.props.maxOutput > 0) stdout.shift()
     
     stdout.push({ message, isEcho: options?.isEcho || false })
 

--- a/src/defs/types/Terminal.js
+++ b/src/defs/types/Terminal.js
@@ -39,7 +39,8 @@ const optionTypes = {
   noEchoBack: PropTypes.bool,
   noHistory: PropTypes.bool,
   noAutoScroll: PropTypes.bool,
-  noNewlineParsing: PropTypes.bool
+  noNewlineParsing: PropTypes.bool,
+  maxOutput: PropTypes.number
 }
 
 const labelTypes = {


### PR DESCRIPTION
I noticed while using react-console-emulator, that the terminal can get very laggy when many high-speed `terminal.pushToStdout()` occur, and it gets much worse when the terminal output begins to be the length of millions. Implementing a solution using refs would be painful, and I think it would be much more reasonable to add the option for other people to use, as it is only one line of code.